### PR TITLE
Fix trailing newlines in gemspec

### DIFF
--- a/all.gemspec
+++ b/all.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
 
   spec.files         = []
 
-  File.read('gems.txt').each_line { |gem| spec.add_dependency(gem) }
+  File.read('gems.txt').each_line { |gem| spec.add_dependency(gem.strip) }
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake'


### PR DESCRIPTION
You were getting trailing newlines after the name of all the dependency gems in your gemspec. I found this because it uncovered a bug in gempact.com